### PR TITLE
登録ボタンの作成

### DIFF
--- a/app/api/plant_regist.ts
+++ b/app/api/plant_regist.ts
@@ -1,0 +1,7 @@
+import apiClient from ".";
+
+
+export async function plant_regist(plant_id: number): Promise<number> {
+    const response = await apiClient.post('users/plants', { plant_id });
+    return response.status;
+}

--- a/app/api/plant_regist.ts
+++ b/app/api/plant_regist.ts
@@ -1,7 +1,7 @@
 import apiClient from ".";
 
 
-export async function plant_regist(plant_id: number): Promise<number> {
+export async function plant_regist(plant_id: string): Promise<number> {
     const response = await apiClient.post('users/plants', { plant_id });
     return response.status;
 }

--- a/app/screens/search/detail.tsx
+++ b/app/screens/search/detail.tsx
@@ -126,7 +126,9 @@ const Detail = () => {
             console.log('IDが存在しません');
           }
         }
-        } />
+        }
+        isRegistered={data?.is_registered}
+         />
       </View>
     </SafeAreaView>
   );

--- a/app/screens/search/detail.tsx
+++ b/app/screens/search/detail.tsx
@@ -4,6 +4,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { usePathname, useRouter, useSearchParams } from 'expo-router/build/hooks';
 import { plant } from '../../../types/plant';
 import { searchPlant } from '../../api/searchPlant';
+import { plant_regist } from '../../api/plant_regist';
+import RegistButton from '../../../components/RegistButton';
 
 
 
@@ -108,6 +110,24 @@ const Detail = () => {
 
         </View>
       </ScrollView>
+      <View style= {{
+        height: 110,
+        backgroundColor: '#68A98A',
+        justifyContent: 'center',
+        position: 'absolute',
+        bottom: 0,
+        width: '100%',
+      }}>
+      <RegistButton  title="+ MyGerdenに登録" onPress={
+        () => {
+          if (data?.id !== undefined) {
+            plant_regist(data.id)
+          } else {
+            console.log('IDが存在しません');
+          }
+        }
+        } />
+      </View>
     </SafeAreaView>
   );
 };
@@ -115,10 +135,11 @@ const Detail = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: 16,
+    padding: 0,
     backgroundColor: '#FFFBF3',
   },
   plantDetail: {
+    margin: 16,
     padding: 16,
     backgroundColor: '#ffffff',
     borderRadius: 30,
@@ -155,6 +176,16 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     marginBottom: 18,
 
+  },
+
+  registerButton: {
+    backgroundColor: 'white',
+    padding: 10,
+    borderRadius: 20,
+    alignItems: 'center',
+    margin: 16,
+    position: 'absolute',
+    bottom: 0,
   }
 });
 

--- a/components/RegistButton.tsx
+++ b/components/RegistButton.tsx
@@ -4,12 +4,19 @@ import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 interface RegistButtonProps {
     onPress: () => void;
     title: string;
+    isRegist?: boolean;
 }
 
-const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title }) => {
+const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title, isRegist }) => {
     return (
-        <TouchableOpacity style={styles.button} onPress={onPress}>
-            <Text style={styles.buttonText}>{title}</Text>
+        <TouchableOpacity style={
+            isRegist ? styles.buttonRegisted : styles.button
+        } onPress={onPress}>
+            <Text style={
+                isRegist ? styles.buttonTextRegisted : styles.buttonText
+            }>{
+                isRegist ? '登録済み' : title
+                }</Text>
         </TouchableOpacity>
     );
 };
@@ -27,6 +34,19 @@ const styles = StyleSheet.create({
         fontSize: 20,
         fontWeight: 'bold',
     },
+    buttonRegisted: {
+        backgroundColor: '#D9D9D9',
+        padding: 10,
+        borderRadius: 20,
+        alignItems: 'center',
+        margin: 16,
+    },
+    buttonTextRegisted: {
+        color: 'black',
+        fontSize: 20,
+        fontWeight: 'bold',
+    },
+    
 });
 
 export default RegistButton;

--- a/components/RegistButton.tsx
+++ b/components/RegistButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+interface RegistButtonProps {
+    onPress: () => void;
+    title: string;
+}
+
+const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title }) => {
+    return (
+        <TouchableOpacity style={styles.button} onPress={onPress}>
+            <Text style={styles.buttonText}>{title}</Text>
+        </TouchableOpacity>
+    );
+};
+
+const styles = StyleSheet.create({
+    button: {
+        backgroundColor: 'white',
+        padding: 10,
+        borderRadius: 20,
+        alignItems: 'center',
+        margin: 16,
+    },
+    buttonText: {
+        color: '#68A98A',
+        fontSize: 20,
+        fontWeight: 'bold',
+    },
+});
+
+export default RegistButton;

--- a/components/RegistButton.tsx
+++ b/components/RegistButton.tsx
@@ -11,7 +11,9 @@ const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title, isRegistere
     return (
         <TouchableOpacity style={
             isRegistered ? styles.buttonRegisted : styles.button
-        } onPress={onPress}>
+        } onPress={
+            isRegistered ? () => {} : onPress
+        }>
             <Text style={
                 isRegistered ? styles.buttonTextRegisted : styles.buttonText
             }>{

--- a/components/RegistButton.tsx
+++ b/components/RegistButton.tsx
@@ -4,18 +4,18 @@ import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 interface RegistButtonProps {
     onPress: () => void;
     title: string;
-    isRegist?: boolean;
+    isRegistered?: boolean;
 }
 
-const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title, isRegist }) => {
+const RegistButton: React.FC<RegistButtonProps> = ({ onPress, title, isRegistered }) => {
     return (
         <TouchableOpacity style={
-            isRegist ? styles.buttonRegisted : styles.button
+            isRegistered ? styles.buttonRegisted : styles.button
         } onPress={onPress}>
             <Text style={
-                isRegist ? styles.buttonTextRegisted : styles.buttonText
+                isRegistered ? styles.buttonTextRegisted : styles.buttonText
             }>{
-                isRegist ? '登録済み' : title
+                isRegistered ? '登録済み' : title
                 }</Text>
         </TouchableOpacity>
     );

--- a/types/plant.ts
+++ b/types/plant.ts
@@ -4,6 +4,7 @@ export type plant = {
     description: string;
     care_periods: [carePeriod];
     growth_conditions: growthConditions;
+    is_registered: boolean;
     }
 
 interface carePeriod {

--- a/types/plant.ts
+++ b/types/plant.ts
@@ -4,7 +4,7 @@ export type plant = {
     description: string;
     care_periods: [carePeriod];
     growth_conditions: growthConditions;
-    is_registered: boolean;
+    is_registered?: boolean;
     }
 
 interface carePeriod {


### PR DESCRIPTION
# やったこと
- 植物の登録ボタンを作成,detailVIewに追加
- plantデータモデルに登録状況を追加修正
- 登録状況によってボタンの活性化制御

# このPRで実現できること
- 詳細画面にて、登録APIを叩き、登録することができる。
- 登録済みかを確認することができる。