### PR TITLE
自動ログインの実装

### DIFF
--- a/app/api/autoLogin.ts
+++ b/app/api/autoLogin.ts
@@ -1,0 +1,17 @@
+import axios from "axios";
+import * as SecureStore from "expo-secure-store";
+
+const loginClient = axios.create({
+    baseURL: "http://localhost:3000",
+});
+
+export async function autoLogin(): Promise<boolean> {
+    const idToken = await SecureStore.getItemAsync('idToken');
+    loginClient.defaults.headers.common['Authorization'] = `Bearer ${idToken}`;
+    const response = await loginClient.get('users/login');
+    if (response.status == 200) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
     View, Text, TextInput, Button, StyleSheet, Image, TouchableOpacity, KeyboardAvoidingView,
     ScrollView,
@@ -9,6 +9,7 @@ import {
 import { useFocusEffect, useRouter } from 'expo-router';
 import { signInWithEmailAndPassword } from "firebase/auth";
 import { auth } from "@/lib/firebase";
+import { autoLogin } from "../app/api/autoLogin";
 
 const Login = () => {
     const router = useRouter();
@@ -16,6 +17,21 @@ const Login = () => {
     const [password, setPassword] = useState('');
     const [focus, setFocus] = useState(false);
     const [error, setError] = useState('');
+
+    useEffect(() => {
+        console.log('Login screen mounted');
+        handleAutoLogin();
+    }, []);
+
+    const handleAutoLogin = async () => {
+        console.log('Auto login');
+        const result = await autoLogin();
+        if (result) {
+            router.replace({ pathname: '../(tabs)' });
+        } else {
+            console.log('Not logged in');
+        }
+    }
     
     const handleLogin = async () => {
         try {

--- a/app/screens/signUp/index.tsx
+++ b/app/screens/signUp/index.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-native';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
-
+import * as SecureStore from 'expo-secure-store';
 const signUp = () => {
     const router = useRouter();
     const [email, setEmail] = useState('');
@@ -23,6 +23,10 @@ const signUp = () => {
         try {
             const auth = getAuth();
             const userCredential = await createUserWithEmailAndPassword(auth, email, password);
+            const idToken = await userCredential.user.getIdToken();
+            const refreshToken = userCredential.user.refreshToken;
+            SecureStore.setItemAsync('idToken', idToken);
+            SecureStore.setItemAsync('refreshToken', refreshToken);
             console.log(userCredential);
             router.replace({ pathname: './signUp/settingProfile' });
         } catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-haptics": "~14.0.0",
         "expo-linking": "~7.0.3",
         "expo-router": "^4.0.11",
+        "expo-secure-store": "^14.0.1",
         "expo-splash-screen": "~0.29.18",
         "expo-sqlite": "^15.0.6",
         "expo-status-bar": "~2.0.0",
@@ -7417,6 +7418,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-14.0.1.tgz",
+      "integrity": "sha512-QUS+j4+UG4jRQalgnpmTvvrFnMVLqPiUZRzYPnG3+JrZ5kwVW2w6YS3WWerPoR7C6g3y/a2htRxRSylsDs+TaQ==",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-splash-screen": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-haptics": "~14.0.0",
     "expo-linking": "~7.0.3",
     "expo-router": "^4.0.11",
+    "expo-secure-store": "^14.0.1",
     "expo-splash-screen": "~0.29.18",
     "expo-sqlite": "^15.0.6",
     "expo-status-bar": "~2.0.0",


### PR DESCRIPTION
# やったこと
- 自動ログイン機能の実装
- 初回ログイン時にToken, refreshTokenをsecureStoreに保存
- /loginAPIを叩く

# このPRで実現できること
- 新規登録以降はlogin処理をしなくても、自動でログインが発火される。